### PR TITLE
一部のみのクエリも反映

### DIFF
--- a/main.js
+++ b/main.js
@@ -62,6 +62,13 @@ window.onload=function(){
   var isfromquery = false;
   var isfromls    = false;
 
+  //default settings 
+  for(var r=0;r<defaultset.relaylist.length;r++){
+    form0.relayliststr.value += defaultset.relaylist[r] + "\n";
+  }
+  form0.eid.value = defaultset.eid;
+  form0.kind.value = 1;
+
   //try to get settings from HTTP query
   var urlsp = getaddr();
   var isfromquery = url2form(urlsp);
@@ -80,13 +87,6 @@ window.onload=function(){
       return;
     }
   }
-
-  //default settings 
-  for(var r=0;r<defaultset.relaylist.length;r++){
-    form0.relayliststr.value += defaultset.relaylist[r] + "\n";
-  }
-  form0.eid.value = defaultset.eid;
-  form0.kind.value = 1;
 
 }
 var handle_copy_button=function(){


### PR DESCRIPTION
2024-01-12 現在、 [nostter](https://nostter.app/) の各イベントの詳細画面から`eid`および`kind`クエリ付きでリンクされていますが、`relay`を含まないためすべてデフォルト値に初期化されてしまいクエリが意味を成していません。
一部クエリだけでも反映させてほしいので、デフォルト値の設定を先に処理し、クエリがある項目だけを上書きで反映するようにしました。
※nostter側で`relay`を含んでリンクするようPRすることも考えましたが、こちらの間口を広げたほうがより公益に資すると考えました